### PR TITLE
Fixing blur parameters

### DIFF
--- a/filters/blur.go
+++ b/filters/blur.go
@@ -33,7 +33,7 @@ func (r *blur) CreateOptions(image *bimg.Image) (*bimg.Options, error) {
 func (r *blur) CreateFilter(args []interface{}) (filters.Filter, error) {
 	var err error
 
-	if len(args) != 2 {
+	if len(args) != 1 && len(args) != 2 {
 		return nil, filters.ErrInvalidFilterParameters
 	}
 
@@ -44,9 +44,13 @@ func (r *blur) CreateFilter(args []interface{}) (filters.Filter, error) {
 		return nil, err
 	}
 
-	f.MinAmpl, err = parse.EskipFloatArg(args[1])
-	if err != nil {
-		return nil, err
+	if len(args) == 2 {
+		f.MinAmpl, err = parse.EskipFloatArg(args[1])
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		f.MinAmpl = 0
 	}
 
 	return f, nil

--- a/filters/blur_test.go
+++ b/filters/blur_test.go
@@ -16,7 +16,7 @@ func TestBlur_Name(t *testing.T) {
 	assert.Equal(t, "blur", c.Name())
 }
 
-func TestBlur_CreateOptions(t *testing.T) {
+func TestBlur_CreateOptions_ExplicitParam(t *testing.T) {
 	image := imagefiltertest.LandscapeImage()
 	blur := blur{Sigma: 19, MinAmpl: 21}
 	options, _ := blur.CreateOptions(image)
@@ -25,6 +25,17 @@ func TestBlur_CreateOptions(t *testing.T) {
 
 	assert.Equal(t, float64(19), blu.Sigma)
 	assert.Equal(t, float64(21), blu.MinAmpl)
+}
+
+func TestBlur_CreateOptions_ImplicitParam(t *testing.T) {
+	image := imagefiltertest.LandscapeImage()
+	blur := blur{Sigma: 19}
+	options, _ := blur.CreateOptions(image)
+
+	blu := options.GaussianBlur
+
+	assert.Equal(t, float64(19), blu.Sigma)
+	assert.Equal(t, float64(0), blu.MinAmpl)
 }
 
 func TestBlur_CreateFilter(t *testing.T) {


### PR DESCRIPTION
In h2non.bimg the MinAmpl parameter is optional and the only required one is sigma. MinAmpl only change a little the blurring effect, while sigma decides the level of blurriness