### PR TITLE
on processing error or empty original skip and close the stream

### DIFF
--- a/filters/imagefilter_test.go
+++ b/filters/imagefilter_test.go
@@ -44,16 +44,6 @@ func assertCorrectImageSize(r io.Reader, t *testing.T) {
 
 }
 
-func TestTransformImage(t *testing.T) {
-	image := imagefiltertest.LandscapeImage()
-
-	r, w := io.Pipe()
-
-	go transformImage(w, image, &optionsTarget)
-
-	assertCorrectImageSize(r, t)
-}
-
 func TestHandleResponse(t *testing.T) {
 	imageReader := createSampleImageReader(t)
 	response := &http.Response{Body: imageReader}
@@ -66,5 +56,3 @@ func TestHandleResponse(t *testing.T) {
 
 	assertCorrectImageSize(fc.Response().Body, t)
 }
-
-


### PR DESCRIPTION
whenever the upstream returns no response (e.g. on 304 not modified) the stream doesn't get closed as transformImage() doesn't get called. moved the method to close it in all cases 

additionally whenever the original bytes length is 0 we skip processing to not catch an exception unnecessarily