### PR TITLE
fixing resize parameter type

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Skrop provides a set of filters, which you can use within the routes:
 * **crop(width, height, type)** — crops the image to have the specified width and height the type can be "north", "south", "east" and "west"
 * **cropByHeight(height, type)** — crops the image to have the specified height
 * **cropByWidth(width, type)** — crops the image to have the specified width
-* **resize(width, height, opt-keep-aspect-ratio)** — resizes an image. Third parameter is optional: "ignoreAspectRatio" to ignore the aspect ratio
+* **resize(width, height, opt-keep-aspect-ratio)** — resizes an image. Third parameter is optional: "ignoreAspectRatio" to ignore the aspect ratio, anything else to keep it
 * **addBackground(R, G, B)** — adds the background to a PNG image with transparency
 * **convertImageType(type)** — converts between different formats (for the list of supported types see [here](https://github.com/h2non/bimg/blob/master/type.go)
 * **sharpen(radius, X1, Y2, Y3, M1, M2)** — sharpens the image (for info about the meaning of the parameters and the suggested values see [here](http://www.vips.ecs.soton.ac.uk/supported/current/doc/html/libvips/libvips-convolution.html#vips-sharpen))

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Skrop provides a set of filters, which you can use within the routes:
 * **crop(width, height, type)** — crops the image to have the specified width and height the type can be "north", "south", "east" and "west"
 * **cropByHeight(height, type)** — crops the image to have the specified height
 * **cropByWidth(width, type)** — crops the image to have the specified width
-* **resize(width, height, opt-keep-aspect-ratio)** — resizes an image. Third parameter is optional: true to keep aspect ratio, false to ignore (default to true)
+* **resize(width, height, opt-keep-aspect-ratio)** — resizes an image. Third parameter is optional: "ignoreAspectRatio" to ignore the aspect ratio
 * **addBackground(R, G, B)** — adds the background to a PNG image with transparency
 * **convertImageType(type)** — converts between different formats (for the list of supported types see [here](https://github.com/h2non/bimg/blob/master/type.go)
 * **sharpen(radius, X1, Y2, Y3, M1, M2)** — sharpens the image (for info about the meaning of the parameters and the suggested values see [here](http://www.vips.ecs.soton.ac.uk/supported/current/doc/html/libvips/libvips-convolution.html#vips-sharpen))

--- a/eskip/sample.eskip
+++ b/eskip/sample.eskip
@@ -58,7 +58,7 @@ withVioletBackground: Path("/images/vio/:image")
 
 resize_no_ratio: Path("/images/dist/:image")
   -> modPath("^/images/dist", "/images")
-  -> resize(255, 25, "false")
+  -> resize(255, 25, "keepAspectRatio")
   -> "http://localhost:9090";
 
 convertImageType: Path("/images/conv/:image")

--- a/eskip/sample.eskip
+++ b/eskip/sample.eskip
@@ -56,6 +56,11 @@ withVioletBackground: Path("/images/vio/:image")
   -> width(1000)
   -> "http://localhost:9090";
 
+resize_no_ratio: Path("/images/dist/:image")
+  -> modPath("^/images/dist", "/images")
+  -> resize(255, 25, "false")
+  -> "http://localhost:9090";
+
 convertImageType: Path("/images/conv/:image")
  -> modPath("^/images/conv", "/images")
  -> convertImageType("jpeg")

--- a/eskip/sample.eskip
+++ b/eskip/sample.eskip
@@ -63,6 +63,7 @@ resize_no_ratio: Path("/images/dist/:image")
 
 convertImageType: Path("/images/conv/:image")
  -> modPath("^/images/conv", "/images")
+ -> resize(50, 100, "ignoreAspectRatio")
  -> convertImageType("jpeg")
  -> "http://localhost:9090";
 

--- a/filters/resize.go
+++ b/filters/resize.go
@@ -6,11 +6,11 @@ import (
 	"github.com/zalando/skipper/filters"
 	"gopkg.in/h2non/bimg.v1"
 	"math"
-	"strconv"
 )
 
 const (
-	ResizeName = "resize"
+	ResizeName           = "resize"
+	ignoreAspectRatioStr = "ignoreAspectRatio"
 )
 
 type resize struct {
@@ -79,15 +79,13 @@ func (r *resize) CreateFilter(args []interface{}) (filters.Filter, error) {
 	}
 
 	if len(args) == 3 {
-		boolStr, err := parse.EskipStringArg(args[2])
+		ratio, err := parse.EskipStringArg(args[2])
 		if err != nil {
 			return nil, err
 		}
 
-		f.keepAspectRatio, err = strconv.ParseBool(boolStr)
-		if err != nil {
-			return nil, err
-		}
+		f.keepAspectRatio = !(ratio == ignoreAspectRatioStr)
+
 	} else {
 		f.keepAspectRatio = true
 	}

--- a/filters/resize.go
+++ b/filters/resize.go
@@ -6,6 +6,7 @@ import (
 	"github.com/zalando/skipper/filters"
 	"gopkg.in/h2non/bimg.v1"
 	"math"
+	"strconv"
 )
 
 const (
@@ -78,8 +79,12 @@ func (r *resize) CreateFilter(args []interface{}) (filters.Filter, error) {
 	}
 
 	if len(args) == 3 {
-		f.keepAspectRatio, err = parse.EskipBoolArg(args[2])
+		boolStr, err := parse.EskipStringArg(args[2])
+		if err != nil {
+			return nil, err
+		}
 
+		f.keepAspectRatio, err = strconv.ParseBool(boolStr)
 		if err != nil {
 			return nil, err
 		}

--- a/filters/resize_test.go
+++ b/filters/resize_test.go
@@ -72,11 +72,11 @@ func TestResize_CreateFilter(t *testing.T) {
 		Err:  false,
 	}, {
 		Msg:  "three args",
-		Args: []interface{}{800.0, 600.0, true},
+		Args: []interface{}{800.0, 600.0, "true"},
 		Err:  false,
 	}, {
 		Msg:  "more than 3 args",
-		Args: []interface{}{800.0, 200.0, true, "Whaaat!"},
+		Args: []interface{}{800.0, 200.0, "true", "Whaaat!"},
 		Err:  true,
 	}})
 }

--- a/filters/resize_test.go
+++ b/filters/resize_test.go
@@ -72,11 +72,30 @@ func TestResize_CreateFilter(t *testing.T) {
 		Err:  false,
 	}, {
 		Msg:  "three args",
-		Args: []interface{}{800.0, 600.0, "true"},
+		Args: []interface{}{800.0, 600.0, "ignoreAspectRatio"},
 		Err:  false,
 	}, {
 		Msg:  "more than 3 args",
-		Args: []interface{}{800.0, 200.0, "true", "Whaaat!"},
+		Args: []interface{}{800.0, 200.0, "test", "Whaaat!"},
 		Err:  true,
 	}})
+}
+
+func TestResize_CreateFilter_IgnoreAspectRatio(t *testing.T) {
+
+	f := &resize{}
+
+	nf, _ := f.CreateFilter([]interface{}{100.0, 50.0, "ignoreAspectRatio"})
+	i := nf.(*resize)
+
+	assert.Equal(t, false, i.keepAspectRatio)
+}
+func TestResize_CreateFilter_KeepAspectRatio(t *testing.T) {
+
+	f := &resize{}
+
+	nf, _ := f.CreateFilter([]interface{}{100.0, 50.0, "anything"})
+	i := nf.(*resize)
+
+	assert.Equal(t, true, i.keepAspectRatio)
 }


### PR DESCRIPTION
skipper cannot recognize Boolean arguments.
I changed the 3rd optional parameter to string: it must be "ignoreAspectRatio" if you want to ignore the aspect ratio, anything else will keep it.