### PR TITLE
Option to avoid enlargement in resize

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ Skrop provides a set of filters, which you can use within the routes:
 * **addBackground(R, G, B)** — adds the background to a PNG image with transparency
 * **convertImageType(type)** — converts between different formats (for the list of supported types see [here](https://github.com/h2non/bimg/blob/master/type.go)
 * **sharpen(radius, X1, Y2, Y3, M1, M2)** — sharpens the image (for info about the meaning of the parameters and the suggested values see [here](http://www.vips.ecs.soton.ac.uk/supported/current/doc/html/libvips/libvips-convolution.html#vips-sharpen))
-* **width(size)** — resizes the image to the specified width keeping the ratio
-* **height(size)** — resizes the image to the specified height keeping the ratio
+* **width(size, opt-enlarge)** — resizes the image to the specified width keeping the ratio. If the second arg is specified and it is equals to "DO_NOT_ENLARGE", the image will not be enlarged
+* **height(size, opt-enlarge)** — resizes the image to the specified height keeping the ratio. If the second arg is specified and it is equals to "DO_NOT_ENLARGE", the image will not be enlarged
 * **blur(sigma, min_ampl)** — blurs the image (for info see [here](http://www.vips.ecs.soton.ac.uk/supported/current/doc/html/libvips/libvips-convolution.html#vips-gaussblur))
 * **imageOverlay(filename, opacity, gravity, opt-top-margin, opt-right-margin, opt-bottom-margin, opt-left-margin)** — puts an image onverlay over the required image
 

--- a/filters/imagefilter.go
+++ b/filters/imagefilter.go
@@ -16,6 +16,7 @@ const (
 	West    = "west"
 	Center  = "center"
 	Quality = 100
+	doNotEnlarge      = "DO_NOT_ENLARGE"
 )
 
 var (

--- a/filters/imagefilter.go
+++ b/filters/imagefilter.go
@@ -10,13 +10,13 @@ import (
 )
 
 const (
-	North   = "north"
-	South   = "south"
-	East    = "east"
-	West    = "west"
-	Center  = "center"
-	Quality = 100
-	doNotEnlarge      = "DO_NOT_ENLARGE"
+	North        = "north"
+	South        = "south"
+	East         = "east"
+	West         = "west"
+	Center       = "center"
+	Quality      = 100
+	doNotEnlarge = "DO_NOT_ENLARGE"
 )
 
 var (

--- a/filters/resizebyheight.go
+++ b/filters/resizebyheight.go
@@ -33,7 +33,7 @@ func (r *resizeByHeight) CreateOptions(image *bimg.Image) (*bimg.Options, error)
 			return nil, err
 		}
 
-		// in case the image is bigger than the requested, do not change it
+		// enlargement not allowed here
 		if size.Height <= r.height {
 			return &bimg.Options{}, nil
 		}
@@ -57,16 +57,15 @@ func (r *resizeByHeight) CreateFilter(args []interface{}) (filters.Filter, error
 		return nil, err
 	}
 
+	f.enlarge = true
+
 	if len(args) == 2 {
-		var cons string
-		cons, err = parse.EskipStringArg(args[1])
+		cons, err := parse.EskipStringArg(args[1])
 		if err != nil {
 			return nil, err
 		}
 
 		f.enlarge = !(cons == doNotEnlarge)
-	} else {
-		f.enlarge = true
 	}
 
 	return f, nil

--- a/filters/resizebyheight.go
+++ b/filters/resizebyheight.go
@@ -2,9 +2,9 @@ package filters
 
 import (
 	log "github.com/Sirupsen/logrus"
+	"github.com/zalando-incubator/skrop/parse"
 	"github.com/zalando/skipper/filters"
 	"gopkg.in/h2non/bimg.v1"
-	"github.com/zalando-incubator/skrop/parse"
 )
 
 const (
@@ -12,7 +12,8 @@ const (
 )
 
 type resizeByHeight struct {
-	height int
+	height  int
+	enlarge bool
 }
 
 func NewResizeByHeight() filters.Spec {
@@ -26,6 +27,18 @@ func (r *resizeByHeight) Name() string {
 func (r *resizeByHeight) CreateOptions(image *bimg.Image) (*bimg.Options, error) {
 	log.Debug("Create options for resize by width ", r)
 
+	if !r.enlarge {
+		size, err := image.Size()
+		if err != nil {
+			return nil, err
+		}
+
+		// in case the image is bigger than the requested, do not change it
+		if size.Height <= r.height {
+			return &bimg.Options{}, nil
+		}
+	}
+
 	return &bimg.Options{
 		Height: r.height}, nil
 }
@@ -33,16 +46,27 @@ func (r *resizeByHeight) CreateOptions(image *bimg.Image) (*bimg.Options, error)
 func (r *resizeByHeight) CreateFilter(args []interface{}) (filters.Filter, error) {
 	var err error
 
-	if len(args) != 1 {
+	if len(args) != 1 && len(args) != 2 {
 		return nil, filters.ErrInvalidFilterParameters
 	}
 
 	f := &resizeByHeight{}
 
 	f.height, err = parse.EskipIntArg(args[0])
-
 	if err != nil {
 		return nil, err
+	}
+
+	if len(args) == 2 {
+		var cons string
+		cons, err = parse.EskipStringArg(args[1])
+		if err != nil {
+			return nil, err
+		}
+
+		f.enlarge = !(cons == doNotEnlarge)
+	} else {
+		f.enlarge = true
 	}
 
 	return f, nil

--- a/filters/resizebyheight_test.go
+++ b/filters/resizebyheight_test.go
@@ -16,12 +16,44 @@ func TestResizeByHeight_Name(t *testing.T) {
 	assert.Equal(t, "height", c.Name())
 }
 
-func TestResizeByHeight_CreateOptions(t *testing.T) {
+func TestResizeByHeight_CreateOptions_Shrink_EnlargeAllowed(t *testing.T) {
 	image := imagefiltertest.LandscapeImage()
-	resizeByHeight := resizeByHeight{height: 150}
+	size, _ := image.Size()
+	newSize := size.Height / 2
+	resizeByHeight := resizeByHeight{height: newSize, enlarge: true}
 	options, _ := resizeByHeight.CreateOptions(image)
 
-	assert.Equal(t, 150, options.Height)
+	assert.Equal(t, newSize, options.Height)
+}
+
+func TestResizeByHeight_CreateOptions_Enlarge_EnlargeAllowed(t *testing.T) {
+	image := imagefiltertest.LandscapeImage()
+	size, _ := image.Size()
+	newSize := size.Height * 2
+	resizeByHeight := resizeByHeight{height: newSize, enlarge: true}
+	options, _ := resizeByHeight.CreateOptions(image)
+
+	assert.Equal(t, newSize, options.Height)
+}
+
+func TestResizeByHeight_CreateOptions_Shrink_EnlargeNotAllowed(t *testing.T) {
+	image := imagefiltertest.LandscapeImage()
+	size, _ := image.Size()
+	newSize := size.Height / 2
+	resizeByHeight := resizeByHeight{height: newSize, enlarge: false}
+	options, _ := resizeByHeight.CreateOptions(image)
+
+	assert.Equal(t, newSize, options.Height)
+}
+
+func TestResizeByHeight_CreateOptions_Enlarge_EnlargeNotAllowed(t *testing.T) {
+	image := imagefiltertest.LandscapeImage()
+	size, _ := image.Size()
+	newSize := size.Height * 2
+	resizeByHeight := resizeByHeight{height: newSize, enlarge: false}
+	options, _ := resizeByHeight.CreateOptions(image)
+
+	assert.Equal(t, 0, options.Height)
 }
 
 func TestResizeByHeight_CreateFilter(t *testing.T) {
@@ -34,8 +66,16 @@ func TestResizeByHeight_CreateFilter(t *testing.T) {
 		Args: []interface{}{256.0},
 		Err:  false,
 	}, {
-		Msg:  "more than one args",
-		Args: []interface{}{256.0, 100.0},
+		Msg:  "two args",
+		Args: []interface{}{100.0, "DO_NOT_ENLARGE"},
+		Err:  false,
+	}, {
+		Msg:  "wrong 2nd args",
+		Args: []interface{}{1000.0, 100.0},
+		Err:  true,
+	}, {
+		Msg:  "more than two args",
+		Args: []interface{}{2000.0, "DO_NOT_ENLARGE", 1.0},
 		Err:  true,
 	}})
 }

--- a/filters/resizebywidth.go
+++ b/filters/resizebywidth.go
@@ -33,7 +33,7 @@ func (r *resizeByWidth) CreateOptions(image *bimg.Image) (*bimg.Options, error) 
 			return nil, err
 		}
 
-		// in case the image is bigger than the requested, do not change it
+		// enlargement not allowed here
 		if size.Width <= r.width {
 			return &bimg.Options{}, nil
 		}
@@ -57,16 +57,15 @@ func (r *resizeByWidth) CreateFilter(args []interface{}) (filters.Filter, error)
 		return nil, err
 	}
 
+	f.enlarge = true
+
 	if len(args) == 2 {
-		var cons string
-		cons, err = parse.EskipStringArg(args[1])
+		cons, err := parse.EskipStringArg(args[1])
 		if err != nil {
 			return nil, err
 		}
 
 		f.enlarge = !(cons == doNotEnlarge)
-	} else {
-		f.enlarge = true
 	}
 
 	return f, nil

--- a/filters/resizebywidth.go
+++ b/filters/resizebywidth.go
@@ -2,9 +2,9 @@ package filters
 
 import (
 	log "github.com/Sirupsen/logrus"
+	"github.com/zalando-incubator/skrop/parse"
 	"github.com/zalando/skipper/filters"
 	"gopkg.in/h2non/bimg.v1"
-	"github.com/zalando-incubator/skrop/parse"
 )
 
 const (
@@ -12,7 +12,8 @@ const (
 )
 
 type resizeByWidth struct {
-	width int
+	width   int
+	enlarge bool
 }
 
 func NewResizeByWidth() filters.Spec {
@@ -26,6 +27,18 @@ func (r *resizeByWidth) Name() string {
 func (r *resizeByWidth) CreateOptions(image *bimg.Image) (*bimg.Options, error) {
 	log.Debug("Create options for resize by width ", r)
 
+	if !r.enlarge {
+		size, err := image.Size()
+		if err != nil {
+			return nil, err
+		}
+
+		// in case the image is bigger than the requested, do not change it
+		if size.Width <= r.width {
+			return &bimg.Options{}, nil
+		}
+	}
+
 	return &bimg.Options{
 		Width: r.width}, nil
 }
@@ -33,16 +46,27 @@ func (r *resizeByWidth) CreateOptions(image *bimg.Image) (*bimg.Options, error) 
 func (r *resizeByWidth) CreateFilter(args []interface{}) (filters.Filter, error) {
 	var err error
 
-	if len(args) != 1 {
+	if len(args) != 1 && len(args) != 2 {
 		return nil, filters.ErrInvalidFilterParameters
 	}
 
 	f := &resizeByWidth{}
 
 	f.width, err = parse.EskipIntArg(args[0])
-
 	if err != nil {
 		return nil, err
+	}
+
+	if len(args) == 2 {
+		var cons string
+		cons, err = parse.EskipStringArg(args[1])
+		if err != nil {
+			return nil, err
+		}
+
+		f.enlarge = !(cons == doNotEnlarge)
+	} else {
+		f.enlarge = true
 	}
 
 	return f, nil

--- a/filters/resizebywidth_test.go
+++ b/filters/resizebywidth_test.go
@@ -16,12 +16,44 @@ func TestResizeByWidth_Name(t *testing.T) {
 	assert.Equal(t, "width", c.Name())
 }
 
-func TestResizeByWidth_CreateOptions(t *testing.T) {
+func TestResizeByWidth_CreateOptions_Shrink_EnlargeAllowed(t *testing.T) {
 	image := imagefiltertest.LandscapeImage()
-	resizeByWidth := resizeByWidth{width: 150}
+	size, _ := image.Size()
+	newSize := size.Width / 2
+	resizeByWidth := resizeByWidth{width: newSize, enlarge: true}
 	options, _ := resizeByWidth.CreateOptions(image)
 
-	assert.Equal(t, 150, options.Width)
+	assert.Equal(t, newSize, options.Width)
+}
+
+func TestResizeByWidth_CreateOptions_Enlarge_EnlargeAllowed(t *testing.T) {
+	image := imagefiltertest.LandscapeImage()
+	size, _ := image.Size()
+	newSize := size.Width * 2
+	resizeByWidth := resizeByWidth{width: newSize, enlarge: true}
+	options, _ := resizeByWidth.CreateOptions(image)
+
+	assert.Equal(t, newSize, options.Width)
+}
+
+func TestResizeByWidth_CreateOptions_Shrink_EnlargeNotAllowed(t *testing.T) {
+	image := imagefiltertest.LandscapeImage()
+	size, _ := image.Size()
+	newSize := size.Width / 2
+	resizeByWidth := resizeByWidth{width: newSize, enlarge: false}
+	options, _ := resizeByWidth.CreateOptions(image)
+
+	assert.Equal(t, newSize, options.Width)
+}
+
+func TestResizeByWidth_CreateOptions_Enlarge_EnlargeNotAllowed(t *testing.T) {
+	image := imagefiltertest.LandscapeImage()
+	size, _ := image.Size()
+	newSize := size.Width * 2
+	resizeByWidth := resizeByWidth{width: newSize, enlarge: false}
+	options, _ := resizeByWidth.CreateOptions(image)
+
+	assert.Equal(t, 0, options.Width)
 }
 
 func TestResizeByWidth_CreateFilter(t *testing.T) {
@@ -34,8 +66,16 @@ func TestResizeByWidth_CreateFilter(t *testing.T) {
 		Args: []interface{}{256.0},
 		Err:  false,
 	}, {
-		Msg:  "more than one args",
-		Args: []interface{}{256.0, 100.0},
+		Msg:  "two args",
+		Args: []interface{}{100.0, "DO_NOT_ENLARGE"},
+		Err:  false,
+	}, {
+		Msg:  "wrong 2nd args",
+		Args: []interface{}{1000.0, 100.0},
+		Err:  true,
+	}, {
+		Msg:  "more than two args",
+		Args: []interface{}{2000.0, "DO_NOT_ENLARGE", 1.0},
 		Err:  true,
 	}})
 }


### PR DESCRIPTION
Added an optional parameter for the filters resizeByWidth and resizeByHeight to avoid enlargement of the image