### PR TITLE
setting white as default background color instead of black

### DIFF
--- a/filters/imagefilter.go
+++ b/filters/imagefilter.go
@@ -115,5 +115,8 @@ func applyDefaults(o *bimg.Options) *bimg.Options {
 	if o.Quality == 0 {
 		o.Quality = Quality
 	}
+	if o.Background == bimg.ColorBlack {
+		o.Background = bimg.Color{R: 255, G: 255, B: 255}
+	}
 	return o
 }


### PR DESCRIPTION
This PR adds by default a white background in case the background is not set