### PR TITLE
fixed overly as per bimg

### DIFF
--- a/filters/overlayImage.go
+++ b/filters/overlayImage.go
@@ -1,7 +1,6 @@
 package filters
 
 import (
-	"errors"
 	"github.com/zalando-incubator/skrop/parse"
 	"github.com/zalando/skipper/filters"
 	"gopkg.in/h2non/bimg.v1"
@@ -104,11 +103,6 @@ func (r *overlay) CreateOptions(image *bimg.Image) (*bimg.Options, error) {
 		y = origSize.Height - r.bottomMargin - overSize.Height
 	}
 
-	// in case y overflows the image
-	if y < 0 || y+overSize.Height > origSize.Height {
-		return nil, errors.New("Error: the overlay image is placed outside the image area on the y axe")
-	}
-
 	switch r.horizontalGravity {
 	case bimg.GravityWest:
 		x = r.leftMargin
@@ -116,11 +110,6 @@ func (r *overlay) CreateOptions(image *bimg.Image) (*bimg.Options, error) {
 		x = r.leftMargin + int(float64(origSize.Width-r.leftMargin-r.rightMargin)/2) - int(float64(overSize.Width)/2)
 	case bimg.GravityEast:
 		x = origSize.Width - r.rightMargin - overSize.Width
-	}
-
-	// in case x overflows the image
-	if x < 0 || x+overSize.Width > origSize.Width {
-		return nil, errors.New("Error: the overlay image is placed outside the image area on the x axe")
 	}
 
 	return &bimg.Options{WatermarkImage: bimg.WatermarkImage{Buf: overArr,

--- a/filters/overlayimage_test.go
+++ b/filters/overlayimage_test.go
@@ -89,42 +89,6 @@ func TestOverlay_CreateOptions_CC(t *testing.T) {
 	assert.Equal(t, int(size.Width/2)-int(overSize.Width/2), over.Left)
 }
 
-func TestOverlay_CreateOptions_OverflowY(t *testing.T) {
-	image := imagefiltertest.LandscapeImage()
-	size, _ := image.Size()
-	overlay := &overlay{file: "../images/star.png",
-		opacity:           0.9,
-		horizontalGravity: bimg.GravityCentre,
-		verticalGravity:   bimg.GravityCentre,
-		leftMargin:        0,
-		rightMargin:       0,
-		topMargin:         size.Height,
-		bottomMargin:      0,
-	}
-
-	options, _ := overlay.CreateOptions(image)
-
-	assert.Nil(t, options)
-}
-
-func TestOverlay_CreateOptions_OverflowX(t *testing.T) {
-	image := imagefiltertest.LandscapeImage()
-	size, _ := image.Size()
-	overlay := &overlay{file: "../images/star.png",
-		opacity:           0.9,
-		horizontalGravity: bimg.GravityCentre,
-		verticalGravity:   bimg.GravityCentre,
-		leftMargin:        size.Width - 5,
-		rightMargin:       0,
-		topMargin:         0,
-		bottomMargin:      0,
-	}
-
-	options, _ := overlay.CreateOptions(image)
-
-	assert.Nil(t, options)
-}
-
 func TestOverlay_CanBeMerged_True(t *testing.T) {
 	s := overlay{}
 	opt := &bimg.Options{}


### PR DESCRIPTION
The current overlay filter doesn't allow the overlay images to be bigger than the originals which cause problems when composed with other filters(resize).
Moreover, bimg allows the overlay images to be bigger than the original image on which we overlay. So I think it's good option to make Skrop in compliant with bimg.